### PR TITLE
 Allow filename to contain version replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ An API to always get the latest assets from a github release.
 curl -LO https://example.com/github/:owner/:repo/:asset-name
 ```
 
+`:asset-name` can contain the following placeholders:
+
+* `%major%` for the major part of the version number
+* `%minor%` for the minor part of the version number
+* `%patch%` for the patch part of the version number
+* `%preRelease%` for the pre-release part of the version number
+* `%build%` for the build part of the version number
+* `%version%` for the full version ID as specified by the release.
+ 
 ## Roadmap
 
 * Include latest assets from GitLab

--- a/src/Domain/Version.php
+++ b/src/Domain/Version.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\GetLatestAssets\Domain;
+
+final class Version
+{
+    private const PATTERN = [
+        '(?P<major>[\d+])',
+        '\.',
+        '(?P<minor>[\d+])',
+        '(\.(?P<patch>[\d+]))?',
+        '(-(?P<preRelease>[a-zA-Z0-9-]+))?',
+        '(\+(?P<build>[a-zA-Z0-9-]+))?',
+    ];
+
+    private int $major = 0;
+
+    private int $minor = 0;
+
+    private int $patch = 0;
+
+    private string $preRelease = '';
+
+    private string $build = '';
+
+    private bool $isSemVer = true;
+
+    public function __construct(private string $version)
+    {
+        if (! preg_match(
+            '/^' . implode('', self::PATTERN) . '$/',
+            $this->version,
+            $parts
+        )) {
+            $this->isSemVer = false;
+            return;
+        }
+
+        if (! isset($parts['patch'])) {
+            $this->isSemVer = false;
+        }
+
+        $this->major = (int)$parts['major'];
+        $this->minor = (int)$parts['minor'];
+        $this->patch = (int)($parts['patch'] ?? 0);
+        $this->preRelease = $parts['preRelease']??'';
+        $this->build = $parts['build']??'';
+    }
+
+    public function getMajor(): int
+    {
+        return $this->major;
+    }
+
+    public function getMinor(): int
+    {
+        return $this->minor;
+    }
+
+    public function getPatch(): int
+    {
+        return $this->patch;
+    }
+
+    public function getPreRelease(): string
+    {
+        return $this->preRelease;
+    }
+
+    public function getBuild(): string
+    {
+        return $this->build;
+    }
+
+    public function isSemVer(): bool
+    {
+        return $this->isSemVer;
+    }
+
+    public function __toString(): string
+    {
+        return $this->version;
+    }
+}

--- a/src/Service/FilenameRewriteService.php
+++ b/src/Service/FilenameRewriteService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\GetLatestAssets\Service;
+
+use Org_Heigl\GetLatestAssets\Domain\Version;
+
+final class FilenameRewriteService
+{
+    public function __construct(
+        private readonly Version $version
+    ) {
+    }
+
+    public function __invoke(string $filename): string
+    {
+        return strtr($filename, [
+            '%version%' => (string) $this->version,
+            '%major%' => $this->version->getMajor(),
+            '%minor%' => $this->version->getMinor(),
+            '%patch%' => $this->version->getPatch(),
+            '%release%' => $this->version->getPreRelease(),
+            '%build%' => $this->version->getBuild(),
+        ]);
+    }
+}

--- a/src/Service/GithubService.php
+++ b/src/Service/GithubService.php
@@ -6,6 +6,7 @@ namespace Org_Heigl\GetLatestAssets\Service;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Uri;
+use Org_Heigl\GetLatestAssets\Domain\Version;
 use Org_Heigl\GetLatestAssets\Exception\AssetNotFound;
 use Org_Heigl\GetLatestAssets\Exception\NoAssetsFound;
 use Org_Heigl\GetLatestAssets\Exception\TroubleWithGithubApiAccess;
@@ -51,6 +52,9 @@ class GithubService
             $constraint
         );
 
-        return new Uri($asset->getAssetUrl($file)->getAssetUrl());
+        $version = new Version($asset->getVersion());
+        $rewriter = new FilenameRewriteService($version);
+
+        return new Uri($asset->getAssetUrl($rewriter($file))->getAssetUrl());
     }
 }

--- a/test/Domain/VersionTest.php
+++ b/test/Domain/VersionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Org_Heigl\GetLatestAssetsTest\Domain;
+
+use Org_Heigl\GetLatestAssets\Domain\Version;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Version::class)]
+class VersionTest extends TestCase
+{
+    #[DataProvider('versionsProvider')]
+    public function testReturningCorrectVersionWorks(
+        string $version,
+        int $major,
+        int $minor,
+        int $patch,
+        string $preRelease,
+        string $build,
+        bool $isSemVer
+    ): void {
+        $versionObj = new Version($version);
+
+        self::assertSame($version, (string)$versionObj);
+        self::assertSame($major, $versionObj->getMajor());
+        self::assertSame($minor, $versionObj->getMinor());
+        self::assertSame($patch, $versionObj->getPatch());
+        self::assertSame($preRelease, $versionObj->getPreRelease());
+        self::assertSame($build, $versionObj->getBuild());
+        self::assertSame($isSemVer, $versionObj->isSemVer());
+    }
+
+    /**
+     * @return array{
+     *     string,
+     *     int,
+     *     int,
+     *     int,
+     *     string,
+     *     string,
+     *     boolean
+     * }[]
+     */
+    public static function versionsProvider(): array
+    {
+        return [
+            ['1.2.3', 1, 2, 3, '', '', true],
+            ['1.2.3-pre-Release', 1, 2, 3, 'pre-Release', '', true],
+            ['1.2.3+build', 1, 2, 3, '', 'build', true],
+            ['1.2.3+build-release', 1, 2, 3, '', 'build-release', true],
+            ['1.2.3-cool-release+my-build', 1, 2, 3, 'cool-release', 'my-build', true],
+            ['bookworm', 0, 0, 0, '', '', false],
+            ['1.2', 1, 2, 0, '', '', false]
+        ];
+    }
+}

--- a/test/Service/FilenameRewriteServiceTest.php
+++ b/test/Service/FilenameRewriteServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Org_Heigl\GetLatestAssetsTest\Service;
+
+use Generator;
+use Org_Heigl\GetLatestAssets\Domain\Version;
+use Org_Heigl\GetLatestAssets\Service\FilenameRewriteService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FilenameRewriteService::class)]
+class FilenameRewriteServiceTest extends TestCase
+{
+    #[DataProvider('provideRewritingWorksAsExpected')]
+    public function testRewritingWorksAsExpected(
+        string $version,
+        string $filename,
+        string $result
+    ): void {
+        $service = new FilenameRewriteService(new Version($version));
+
+        self::assertEquals($result, $service($filename));
+    }
+
+    /**
+     * @return array{
+     *     string,
+     *     string,
+     *     string
+     * }[]
+     */
+    public static function provideRewritingWorksAsExpected(): array
+    {
+        return [
+            ['1.2.3', 'foo.%major%.%minor%.txt', 'foo.1.2.txt'],
+        ];
+    }
+}


### PR DESCRIPTION
This makes it possible to handle assets whos name contains version specific parts.

Like a version 74.1 that contains an asset with filename `asset-74.1.tgz` which can now be referenced using `asset-%major%.%minor%.tgz`

The replacement will be done before fetching the asset but after version matching. So that it will also work for a version constraint of `^74.0`