### PR TITLE
Fetch all releasesm not only first page

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ ssh $SERVER "tar xz -f \"/var/www/com.getlatestassets.api/$HASH.tgz\" -C \"/var/
 ssh $SERVER "chmod 777 \"/var/www/com.getlatestassets.api/$HASH/data\""
 ssh $SERVER "rm -rf \"/var/www/com.getlatestassets.api/$HASH.tgz\" && echo \"Removed tgz\""
 ssh $SERVER "cd \"/var/www/com.getlatestassets.api\" && cp current/.env \"$HASH/.env\" && rm current && ln -s \"$HASH\" \"current\" && echo \"Set symbolic link\""
-ssh $SERVER "cd \"/var/www/com.getlatestassets.api\" && chmod 777 data/cache && sudo service php8.3-fpm restart && echo \"Updated stuff\""
+ssh $SERVER "cd \"/var/www/com.getlatestassets.api\" && chmod 777 current/data/cache && sudo service php8.3-fpm restart && echo \"Updated stuff\""
 ssh $SERVER "cd \"/var/www/com.getlatestassets.api\" && ls -tl -I home -I current | sed /^total/d | tail -n +3 | cut -d \" \" -f 9 | rm -rf && echo \"Removed obsolete folders\""
 
 cd ..

--- a/src/Infrastructure/DiProvider.php
+++ b/src/Infrastructure/DiProvider.php
@@ -52,7 +52,7 @@ final class DiProvider
                     'base_uri' => 'https://api.github.com',
                     'headers' => [
                         'Accept' => 'application/vnd.github.v3+json',
-                        'Authorization' => $_ENV['GITHUB_API_KEY']??'',
+                        'Authorization' => "Bearer " . ($_ENV['GITHUB_API_KEY']??''),
                     ]
                 ]);
             },

--- a/src/Link.php
+++ b/src/Link.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\GetLatestAssets;
+
+final class Link
+{
+    private function __construct(
+        public readonly string $url,
+        public readonly string $relation
+    ) {
+    }
+    public static function fromString(string $header): Link
+    {
+        $data = explode(';', $header);
+        $url = str_replace(['<','>'], ['', ''], trim($data[0]));
+        $relation = str_replace(['rel=', '"'], ['', ''], trim($data[1]));
+
+        return new self($url, $relation);
+    }
+}

--- a/src/Links.php
+++ b/src/Links.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\GetLatestAssets;
+
+final class Links
+{
+    /**
+     * @var array<string, Link>
+     */
+    private array $links;
+    private function __construct(Link ...$links)
+    {
+        foreach ($links as $link) {
+            $this->links[$link->relation] = $link;
+        }
+    }
+    public static function fromHeader(string $header): Links
+    {
+        $links = [];
+        foreach (explode(",", $header) as $line) {
+            $links[] = Link::fromString($line);
+        }
+        return new self(...$links);
+    }
+
+    public function getLink(string $relation): Link|null
+    {
+        return $this->links[$relation]??null;
+    }
+}

--- a/src/Service/ConvertGithubReleaseListService.php
+++ b/src/Service/ConvertGithubReleaseListService.php
@@ -11,10 +11,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class ConvertGithubReleaseListService
 {
-    public function getReleaseList(ResponseInterface $response) : ReleaseList
+    public function addToReleaseList(ReleaseList $list, ResponseInterface $response) : ReleaseList
     {
-        $list = new ReleaseList();
-
         /** @var array{
          *      assets?: array{
          *          name: string,

--- a/test/Service/ConvertGithubReleaseListServiceTest.php
+++ b/test/Service/ConvertGithubReleaseListServiceTest.php
@@ -24,7 +24,8 @@ class ConvertGithubReleaseListServiceTest extends TestCase
         $interface->method('getBody')->willReturn($body);
         $service = new ConvertGithubReleaseListService();
 
-        $releases = $service->getReleaseList($interface);
+        $releases = new ReleaseList();
+        $releases = $service->addToReleaseList($releases, $interface);
 
         self::assertInstanceOf(ReleaseList::class, $releases);
 

--- a/test/Service/GithubServiceTest.php
+++ b/test/Service/GithubServiceTest.php
@@ -57,6 +57,7 @@ class GithubServiceTest extends TestCase
     public function testService(): void
     {
         $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $response->method('getHeader')->willReturn(['<url>; rel="alternate"; hreflang="en"']);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
         $client->method('get')
@@ -65,17 +66,19 @@ class GithubServiceTest extends TestCase
 
         $releaseList = new ReleaseList();
 
-        $convertService = $this->getMockBuilder(ConvertGithubReleaseListService::class)->getMock();
-        $convertService->method('getReleaseList')
-                       ->with($response)
-                       ->willReturn($releaseList);
-
+        $newReleaseList = new ReleaseList();
         $release = new Release('1.0.0', new AssetUrl('name', 'http://example.com/foo?bar=baz#foob'));
-        $releaseList->addRelease($release);
+        $newReleaseList->addRelease($release);
+
+        $convertService = $this->getMockBuilder(ConvertGithubReleaseListService::class)->getMock();
+        $convertService->method('addToReleaseList')
+                       ->with($releaseList, $response)
+                       ->willReturn($newReleaseList);
+
 
         $versionService = $this->getMockBuilder(VersionService::class)->getMock();
         $versionService->method('getLatestAssetForConstraintFromResult')
-                       ->with($releaseList, null)
+                       ->with($newReleaseList, null)
                        ->willReturn($release);
 
         $caching = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();


### PR DESCRIPTION
This will now fetch all releases for a project and no longer only the first page. This will take a while on first call as it needs to fetch the data from the release-list over and over again (for PHPStan that's about 11 pages of each 50 releases).

After caching the resaponse is much faster though!

Fixes #12 